### PR TITLE
chore: ignore node modules and document npm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ logs/
 # Docker
 .dockerignore
 
+# Node
+node_modules/
+
 # Temporary files
 *.tmp
 *.temp

--- a/README.md
+++ b/README.md
@@ -30,12 +30,17 @@ This is a 6-week MVP to prove the core loop: **data → rule → AI prompt → s
    # Add your OPENAI_API_KEY when ready for Week 3
    ```
 
-3. **Start the application**
+3. **Install frontend dependencies**
+   ```bash
+   npm --prefix whispr/ui install
+   ```
+
+4. **Start the application**
    ```bash
    docker compose up --build
    ```
 
-4. **Verify it's working**
+5. **Verify it's working**
    - Health check: http://localhost:8000/
    - API docs: http://localhost:8000/docs
    - WebSocket: ws://localhost:8000/ws/ticks

--- a/whispr/ui/README.md
+++ b/whispr/ui/README.md
@@ -2,7 +2,13 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+Install dependencies:
+
+```bash
+npm install
+```
+
+Then run the development server:
 
 ```bash
 npm run dev


### PR DESCRIPTION
## Summary
- ignore `node_modules` directories across the repo
- note `npm install` in setup instructions for the project
- add dependency installation step to UI README

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68a8da7137d083288f9282bb650128ff