### PR TITLE
feat: add pluggable data provider

### DIFF
--- a/backend/data_providers/__init__.py
+++ b/backend/data_providers/__init__.py
@@ -1,0 +1,5 @@
+from .base import DataProvider
+from .simulated import SimulatedProvider
+from .schwab import SchwabProvider
+
+__all__ = ["DataProvider", "SimulatedProvider", "SchwabProvider"]

--- a/backend/data_providers/base.py
+++ b/backend/data_providers/base.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+from typing import AsyncIterator, Dict, Any
+
+class DataProvider(ABC):
+    """Abstract interface for streaming market data."""
+
+    @abstractmethod
+    async def connect(self) -> None:
+        """Establish any network connections or start background tasks."""
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """Clean up resources before shutdown."""
+
+    @abstractmethod
+    async def subscribe(self) -> AsyncIterator[Dict[str, Any]]:
+        """Yield tick data dictionaries indefinitely."""
+        raise StopAsyncIteration

--- a/backend/data_providers/schwab.py
+++ b/backend/data_providers/schwab.py
@@ -1,0 +1,15 @@
+from typing import AsyncIterator, Dict, Any
+
+from .base import DataProvider
+
+class SchwabProvider(DataProvider):
+    """Placeholder for future Schwab brokerage integration."""
+
+    async def connect(self) -> None:
+        raise NotImplementedError("SchwabProvider.connect is not implemented")
+
+    async def disconnect(self) -> None:
+        pass
+
+    async def subscribe(self) -> AsyncIterator[Dict[str, Any]]:
+        raise NotImplementedError("SchwabProvider.subscribe is not implemented")

--- a/backend/data_providers/simulated.py
+++ b/backend/data_providers/simulated.py
@@ -1,0 +1,24 @@
+import asyncio
+from typing import AsyncIterator, Dict, Any
+
+from .base import DataProvider
+
+class SimulatedProvider(DataProvider):
+    """Simple tick generator for local development and testing."""
+
+    def __init__(self) -> None:
+        self._tick = 0
+        self._running = False
+
+    async def connect(self) -> None:
+        self._running = True
+
+    async def disconnect(self) -> None:
+        self._running = False
+
+    async def subscribe(self) -> AsyncIterator[Dict[str, Any]]:
+        while self._running:
+            tick_data = {"tick": self._tick, "value": 100 + self._tick}
+            self._tick += 1
+            yield tick_data
+            await asyncio.sleep(1)

--- a/backend/database.py
+++ b/backend/database.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 DB_PATH = Path(os.getenv("DB_PATH", "/app/data/whispr.db"))
-DB_PATH.parent.mkdir(parents=True, exist_ok=True)  # /app/data
+DB_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 CREATE_SQL = """
 CREATE TABLE IF NOT EXISTS events (
@@ -17,22 +17,24 @@ CREATE TABLE IF NOT EXISTS events (
 CREATE TABLE IF NOT EXISTS rules (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,
     name         TEXT NOT NULL,
-    trigger_expr TEXT NOT NULL,   -- e.g. "value > 105"
-    prompt_tpl   TEXT NOT NULL,   -- templated text for the LLM
+    trigger_expr TEXT NOT NULL,
+    prompt_tpl   TEXT NOT NULL,
     is_active    INTEGER DEFAULT 1
 );
 """
 
+
 async def get_db():
     """Return a singleton connection (FastAPI will reuse it)."""
     if not hasattr(get_db, "conn"):
-        get_db.conn = await aiosqlite.connect(DB_PATH, isolation_level=None)  # autocommit
+        get_db.conn = await aiosqlite.connect(DB_PATH, isolation_level=None)
         await get_db.conn.execute(CREATE_SQL)
     return get_db.conn
 
-async def log_event(event_type: str, payload: dict):
+
+async def log_event(event_type: str, payload: dict) -> None:
     conn = await get_db()
     await conn.execute(
         "INSERT INTO events (ts, event_type, payload) VALUES (datetime('now'), ?, ?)",
         (event_type, json.dumps(payload)),
-    ) 
+    )

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -1,18 +1,17 @@
 import os
-import json
 from openai import OpenAI
+
 from database import log_event
 
-# Configuration
 GROQ_BASE_URL = "https://api.groq.com/openai/v1"
 OPENAI_BASE_URL = "https://api.openai.com/v1"
 
-# Default to Groq for cost efficiency
 LLM_PROVIDER = os.getenv("LLM_PROVIDER", "groq")
 LLM_MODEL = os.getenv("LLM_MODEL", "llama3-8b-8192")
-LLM_API_KEY = os.getenv("GROQ_API_KEY") if LLM_PROVIDER == "groq" else os.getenv("OPENAI_API_KEY")
+LLM_API_KEY = (
+    os.getenv("GROQ_API_KEY") if LLM_PROVIDER == "groq" else os.getenv("OPENAI_API_KEY")
+)
 
-# Cost tracking (per 1M tokens)
 COSTS = {
     "groq": {
         "llama3-8b-8192": {"input": 0.05, "output": 0.08},
@@ -21,89 +20,86 @@ COSTS = {
     "openai": {
         "gpt-4o-mini": {"input": 0.15, "output": 0.60},
         "gpt-4o": {"input": 2.50, "output": 10.00},
-    }
+    },
 }
 
-def get_client():
+
+def get_client() -> OpenAI:
     """Return configured OpenAI client for either Groq or OpenAI."""
     base_url = GROQ_BASE_URL if LLM_PROVIDER == "groq" else OPENAI_BASE_URL
-    return OpenAI(
-        api_key=LLM_API_KEY,
-        base_url=base_url
-    )
+    return OpenAI(api_key=LLM_API_KEY, base_url=base_url)
+
 
 async def call_llm(messages: list, max_tokens: int = 150) -> dict:
-    """
-    Call LLM and return response with cost tracking.
-    
-    Args:
-        messages: List of message dicts with 'role' and 'content'
-        max_tokens: Maximum tokens for response
-    
-    Returns:
-        dict with 'content', 'usage', 'cost_estimate', 'model'
-    """
+    """Call LLM and return response with cost tracking."""
     try:
         client = get_client()
-        
         response = client.chat.completions.create(
             model=LLM_MODEL,
             messages=messages,
             max_tokens=max_tokens,
-            temperature=0.7
+            temperature=0.7,
         )
-        
-        # Calculate cost estimate
+
         usage = response.usage
-        model_costs = COSTS[LLM_PROVIDER].get(LLM_MODEL, COSTS[LLM_PROVIDER]["llama3-8b-8192"])
-        cost_estimate = (
-            (usage.prompt_tokens / 1_000_000) * model_costs["input"] +
-            (usage.completion_tokens / 1_000_000) * model_costs["output"]
+        model_costs = COSTS[LLM_PROVIDER].get(
+            LLM_MODEL, COSTS[LLM_PROVIDER]["llama3-8b-8192"]
         )
-        
+        cost_estimate = (
+            (usage.prompt_tokens / 1_000_000) * model_costs["input"]
+            + (usage.completion_tokens / 1_000_000) * model_costs["output"]
+        )
+
         result = {
             "content": response.choices[0].message.content,
             "usage": {
                 "prompt_tokens": usage.prompt_tokens,
                 "completion_tokens": usage.completion_tokens,
-                "total_tokens": usage.total_tokens
+                "total_tokens": usage.total_tokens,
             },
             "cost_estimate": round(cost_estimate, 6),
-            "model": f"{LLM_PROVIDER}/{LLM_MODEL}"
+            "model": f"{LLM_PROVIDER}/{LLM_MODEL}",
         }
-        
-        # Log the LLM call for analytics
-        await log_event("llm_call", {
-            "provider": LLM_PROVIDER,
-            "model": LLM_MODEL,
-            "prompt_tokens": usage.prompt_tokens,
-            "completion_tokens": usage.completion_tokens,
-            "cost_estimate": result["cost_estimate"],
-            "response_length": len(result["content"])
-        })
-        
+
+        await log_event(
+            "llm_call",
+            {
+                "provider": LLM_PROVIDER,
+                "model": LLM_MODEL,
+                "prompt_tokens": usage.prompt_tokens,
+                "completion_tokens": usage.completion_tokens,
+                "cost_estimate": result["cost_estimate"],
+                "response_length": len(result["content"]),
+            },
+        )
+
         return result
-        
-    except Exception as e:
-        # Log error for debugging
-        await log_event("llm_error", {
-            "provider": LLM_PROVIDER,
-            "model": LLM_MODEL,
-            "error": str(e)
-        })
+
+    except Exception as e:  # pragma: no cover - defensive
+        await log_event(
+            "llm_error",
+            {
+                "provider": LLM_PROVIDER,
+                "model": LLM_MODEL,
+                "error": str(e),
+            },
+        )
         raise e
 
-def get_cost_comparison():
+
+def get_cost_comparison() -> dict:
     """Return cost comparison for different models."""
     return {
         "current": {
             "provider": LLM_PROVIDER,
             "model": LLM_MODEL,
-            "costs": COSTS[LLM_PROVIDER].get(LLM_MODEL, COSTS[LLM_PROVIDER]["llama3-8b-8192"])
+            "costs": COSTS[LLM_PROVIDER].get(
+                LLM_MODEL, COSTS[LLM_PROVIDER]["llama3-8b-8192"]
+            ),
         },
         "alternatives": {
             "groq_llama3_70b": COSTS["groq"]["llama3-70b-8192"],
             "openai_gpt4o_mini": COSTS["openai"]["gpt-4o-mini"],
-            "openai_gpt4o": COSTS["openai"]["gpt-4o"]
-        }
-    } 
+            "openai_gpt4o": COSTS["openai"]["gpt-4o"],
+        },
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,42 +1,52 @@
-from fastapi import FastAPI, WebSocket
+import os
 import asyncio
 import json
+from fastapi import FastAPI, WebSocket
+
 from database import log_event, get_db
 from llm import get_cost_comparison, call_llm
 from rules import check_rules, seed_test_rules
+from data_providers import DataProvider, SimulatedProvider, SchwabProvider
 
 app = FastAPI(title="Whispr-MVP")
+provider: DataProvider | None = None
+
 
 @app.on_event("startup")
-async def startup_event():
-    """Seed test rules on startup."""
+async def startup_event() -> None:
+    """Seed test rules and initialize the data provider."""
     await seed_test_rules()
+    global provider
+    name = os.getenv("DATA_PROVIDER", "simulated").lower()
+    provider = SchwabProvider() if name == "schwab" else SimulatedProvider()
+    await provider.connect()
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    if provider:
+        await provider.disconnect()
+
 
 @app.get("/")
 async def root():
     return {"status": "OK", "message": "Whispr backend running"}
 
+
 @app.websocket("/ws/ticks")
 async def websocket_ticks(ws: WebSocket):
     await ws.accept()
-    tick = 0
-    while True:
-        tick_data = {"tick": tick, "value": 100 + tick}
-        await log_event("tick", tick_data)  # Log before broadcasting
+    assert provider is not None
+    async for tick_data in provider.subscribe():
+        await log_event("tick", tick_data)
         await ws.send_json(tick_data)
 
-        # NEW: evaluate rules
         async for rule in check_rules(tick_data):
             try:
-                # Format prompt template with tick data
                 prompt = rule["tpl"].format(**tick_data)
-                
-                # Call LLM with the prompt
-                llm_response = await call_llm([
-                    {"role": "user", "content": prompt}
-                ])
-                
-                # Create suggestion payload
+                llm_response = await call_llm(
+                    [{"role": "user", "content": prompt}]
+                )
                 suggestion_payload = {
                     "type": "suggestion",
                     "rule_id": rule["id"],
@@ -45,49 +55,59 @@ async def websocket_ticks(ws: WebSocket):
                     "response": llm_response["content"],
                     "cost": llm_response["cost_estimate"],
                     "model": llm_response["model"],
-                    "tick_data": tick_data
+                    "tick_data": tick_data,
                 }
-                
-                # Log the prompt event
-                await log_event("prompt", {
-                    "rule_id": rule["id"],
-                    "prompt": prompt,
-                    "response": llm_response["content"],
-                    "cost": llm_response["cost_estimate"],
-                    "model": llm_response["model"]
-                })
-                
-                # Send suggestion over WebSocket
+                await log_event(
+                    "prompt",
+                    {
+                        "rule_id": rule["id"],
+                        "prompt": prompt,
+                        "response": llm_response["content"],
+                        "cost": llm_response["cost_estimate"],
+                        "model": llm_response["model"],
+                    },
+                )
                 await ws.send_json(suggestion_payload)
-                
-            except Exception as e:
-                # Log any errors
-                await log_event("rule_error", {
-                    "rule_id": rule["id"],
-                    "error": str(e)
-                })
-        
-        await asyncio.sleep(1)        # 1-Hz simulated stream
-        tick += 1
+            except Exception as e:  # pragma: no cover - defensive
+                await log_event(
+                    "rule_error",
+                    {
+                        "rule_id": rule["id"],
+                        "error": str(e),
+                    },
+                )
+
 
 @app.get("/last_events")
 async def last_events(limit: int = 5):
     conn = await get_db()
     rows = await conn.execute_fetchall(
-        "SELECT ts, event_type, payload FROM events ORDER BY id DESC LIMIT ?", (limit,)
+        "SELECT ts, event_type, payload FROM events ORDER BY id DESC LIMIT ?",
+        (limit,),
     )
     return [{"ts": r[0], "type": r[1], "payload": json.loads(r[2])} for r in rows]
+
 
 @app.get("/costs")
 async def get_costs():
     """Get cost comparison for different LLM providers and models."""
     return get_cost_comparison()
 
+
 @app.get("/rules")
 async def get_rules():
     """Get all active rules."""
     conn = await get_db()
     rows = await conn.execute_fetchall(
-        "SELECT id, name, trigger_expr, prompt_tpl, is_active FROM rules ORDER BY id"
+        "SELECT id, name, trigger_expr, prompt_tpl, is_active FROM rules ORDER BY id",
     )
-    return [{"id": r[0], "name": r[1], "trigger_expr": r[2], "prompt_tpl": r[3], "is_active": bool(r[4])} for r in rows] 
+    return [
+        {
+            "id": r[0],
+            "name": r[1],
+            "trigger_expr": r[2],
+            "prompt_tpl": r[3],
+            "is_active": bool(r[4]),
+        }
+        for r in rows
+    ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
 fastapi>=0.111
 uvicorn>=0.30
 aiosqlite>=0.19
-openai>=1.0.0 
+openai>=1.0.0

--- a/backend/rules.py
+++ b/backend/rules.py
@@ -1,6 +1,7 @@
 import json
 import ast
 import operator
+
 from database import get_db
 
 SAFE_OPS = {
@@ -11,12 +12,11 @@ SAFE_OPS = {
     ast.Eq: operator.eq,
 }
 
+
 def _safe_eval(expr, context):
-    """
-    A very small and safe evaluator: supports comparisons like value > 105.
-    """
+    """A very small and safe evaluator: supports comparisons like value > 105."""
     try:
-        tree = ast.parse(expr, mode="eval").body  # type: ast.AST
+        tree = ast.parse(expr, mode="eval").body  # type: ignore[attr-defined]
         if isinstance(tree, ast.Compare):
             left = _safe_eval(ast.unparse(tree.left), context)
             right = _safe_eval(ast.unparse(tree.comparators[0]), context)
@@ -26,11 +26,15 @@ def _safe_eval(expr, context):
     except Exception:
         return False
 
+
 async def load_rules():
     """Load all active rules from the database."""
     conn = await get_db()
-    rows = await conn.execute_fetchall("SELECT id, name, trigger_expr, prompt_tpl FROM rules WHERE is_active=1")
+    rows = await conn.execute_fetchall(
+        "SELECT id, name, trigger_expr, prompt_tpl FROM rules WHERE is_active=1"
+    )
     return [dict(zip(("id", "name", "expr", "tpl"), r)) for r in rows]
+
 
 async def check_rules(tick):
     """Check if any rules match the current tick data."""
@@ -38,30 +42,43 @@ async def check_rules(tick):
         if _safe_eval(rule["expr"], tick):
             yield rule
 
-async def add_rule(name: str, trigger_expr: str, prompt_tpl: str):
+
+async def add_rule(name: str, trigger_expr: str, prompt_tpl: str) -> None:
     """Add a new rule to the database."""
     conn = await get_db()
     await conn.execute(
         "INSERT INTO rules (name, trigger_expr, prompt_tpl) VALUES (?, ?, ?)",
-        (name, trigger_expr, prompt_tpl)
+        (name, trigger_expr, prompt_tpl),
     )
 
-async def seed_test_rules():
+
+async def seed_test_rules() -> None:
     """Add some test rules to get started."""
     test_rules = [
-        ("High price ping", "value >= 105", "Price crossed {{value}}. Any risk-reducing actions?"),
-        ("Low price alert", "value <= 95", "Price dropped to {{value}}. Consider buying opportunity?"),
-        ("Tick milestone", "tick % 10 == 0", "Reached tick {{tick}} with value {{value}}. Market pattern analysis?")
+        (
+            "High price ping",
+            "value >= 105",
+            "Price crossed {{value}}. Any risk-reducing actions?",
+        ),
+        (
+            "Low price alert",
+            "value <= 95",
+            "Price dropped to {{value}}. Consider buying opportunity?",
+        ),
+        (
+            "Tick milestone",
+            "tick % 10 == 0",
+            "Reached tick {{tick}} with value {{value}}. Market pattern analysis?",
+        ),
     ]
-    
+
     conn = await get_db()
     for name, expr, tpl in test_rules:
-        # Check if rule already exists
         existing = await conn.execute_fetchall(
             "SELECT id FROM rules WHERE name = ?", (name,)
         )
         if not existing:
             await conn.execute(
                 "INSERT INTO rules (name, trigger_expr, prompt_tpl) VALUES (?, ?, ?)",
-                (name, expr, tpl)
-            ) 
+                (name, expr, tpl),
+            )

--- a/env.example
+++ b/env.example
@@ -8,3 +8,6 @@ OPENAI_API_KEY=your_openai_api_key_here
 
 # Database Configuration
 DB_PATH=/app/data/whispr.db
+
+# Data Provider selection: simulated or schwab
+DATA_PROVIDER=simulated


### PR DESCRIPTION
## Summary
- add abstract DataProvider interface with simulated and Schwab implementations
- switch backend tick streamer to use pluggable provider based on DATA_PROVIDER env var
- clean up backend files with stray shell prompts and ensure newlines

## Testing
- `python -m py_compile backend/*.py backend/data_providers/*.py`
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_68a8d6b8af748328b355218da04f2cf0