### PR TITLE
refactor: introduce data provider abstraction

### DIFF
--- a/backend/data_providers/__init__.py
+++ b/backend/data_providers/__init__.py
@@ -1,0 +1,5 @@
+from .base import DataProvider
+from .simulated import SimulatedProvider
+from .schwab import SchwabProvider
+
+__all__ = ["DataProvider", "SimulatedProvider", "SchwabProvider"]

--- a/backend/data_providers/base.py
+++ b/backend/data_providers/base.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import AsyncIterator, Dict, Any
+
+
+class DataProvider(ABC):
+    """Abstract interface for market data providers."""
+
+    @abstractmethod
+    async def connect(self) -> None:
+        """Establish connection to the underlying data source."""
+
+    @abstractmethod
+    async def subscribe(self, symbol: str) -> AsyncIterator[Dict[str, Any]]:
+        """Yield tick data for the given symbol."""
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """Close connection to the data source."""

--- a/backend/data_providers/schwab.py
+++ b/backend/data_providers/schwab.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import AsyncIterator, Dict, Any
+
+from .base import DataProvider
+
+try:  # Optional: external collector is heavy and may not be available during tests
+    from whispr.backend.data_collector import SchwabDataCollector  # type: ignore
+except Exception:  # pragma: no cover - collector may not exist in all envs
+    SchwabDataCollector = None  # type: ignore
+
+
+class SchwabProvider(DataProvider):
+    """Data provider that proxies to the Schwab API collector."""
+
+    def __init__(self, collector: "SchwabDataCollector") -> None:
+        if SchwabDataCollector is None:
+            raise ImportError("SchwabDataCollector is not available")
+        self.collector = collector
+
+    async def connect(self) -> None:
+        await self.collector.connect()
+
+    async def subscribe(self, symbol: str) -> AsyncIterator[Dict[str, Any]]:
+        async for tick in self.collector.stream_real_time([symbol]):
+            yield {
+                "symbol": tick.symbol,
+                "price": tick.price,
+                "high": tick.high,
+                "low": tick.low,
+                "volume": tick.volume,
+                "timestamp": tick.timestamp.isoformat(),
+            }
+
+    async def disconnect(self) -> None:
+        await self.collector.disconnect()

--- a/backend/data_providers/simulated.py
+++ b/backend/data_providers/simulated.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Dict, Any
+
+from .base import DataProvider
+
+
+class SimulatedProvider(DataProvider):
+    """Simple in-memory tick simulator used for development."""
+
+    def __init__(self, delay: float = 1.0) -> None:
+        self.delay = delay
+        self._running = False
+
+    async def connect(self) -> None:
+        self._running = True
+
+    async def subscribe(self, symbol: str) -> AsyncIterator[Dict[str, Any]]:
+        tick = 0
+        while self._running:
+            yield {"symbol": symbol, "tick": tick, "value": 100 + tick}
+            tick += 1
+            await asyncio.sleep(self.delay)
+
+    async def disconnect(self) -> None:
+        self._running = False


### PR DESCRIPTION
## Summary
- add abstract `DataProvider` interface
- implement `SimulatedProvider` and `SchwabProvider`
- inject `DataProvider` into tick streaming for flexible backends

## Testing
- `python -m py_compile backend/data_providers/base.py backend/data_providers/simulated.py backend/data_providers/schwab.py backend/main.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68a8da73c7e08328aecaaeec89abf74c