### PR TITLE
Add Alembic migrations and initial schema

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,37 @@
+# Backend
+
+## Database migrations
+
+This backend uses [Alembic](https://alembic.sqlalchemy.org/) to manage the SQLite schema.
+
+### Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+### Apply migrations
+
+```bash
+cd backend
+alembic upgrade head
+```
+
+To target a specific database file, set the `DB_PATH` environment variable:
+
+```bash
+DB_PATH=/path/to/whispr.db alembic upgrade head
+```
+
+### Create a new migration
+
+```bash
+cd backend
+alembic revision -m "add something"
+```
+
+### Downgrade (optional)
+
+```bash
+alembic downgrade -1
+```

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = sqlite:///
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s %(name)s %(message)s

--- a/backend/database.py
+++ b/backend/database.py
@@ -6,33 +6,17 @@ from pathlib import Path
 DB_PATH = Path(os.getenv("DB_PATH", "/app/data/whispr.db"))
 DB_PATH.parent.mkdir(parents=True, exist_ok=True)  # /app/data
 
-CREATE_SQL = """
-CREATE TABLE IF NOT EXISTS events (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    ts          TEXT NOT NULL,
-    event_type  TEXT NOT NULL,
-    payload     TEXT
-);
-
-CREATE TABLE IF NOT EXISTS rules (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    name         TEXT NOT NULL,
-    trigger_expr TEXT NOT NULL,   -- e.g. "value > 105"
-    prompt_tpl   TEXT NOT NULL,   -- templated text for the LLM
-    is_active    INTEGER DEFAULT 1
-);
-"""
 
 async def get_db():
     """Return a singleton connection (FastAPI will reuse it)."""
     if not hasattr(get_db, "conn"):
         get_db.conn = await aiosqlite.connect(DB_PATH, isolation_level=None)  # autocommit
-        await get_db.conn.execute(CREATE_SQL)
     return get_db.conn
+
 
 async def log_event(event_type: str, payload: dict):
     conn = await get_db()
     await conn.execute(
         "INSERT INTO events (ts, event_type, payload) VALUES (datetime('now'), ?, ?)",
         (event_type, json.dumps(payload)),
-    ) 
+    )

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,43 @@
+import os
+from pathlib import Path
+from alembic import context
+from sqlalchemy import create_engine, pool
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Database URL constructed from DB_PATH env var, defaulting to the runtime path
+DB_PATH = Path(os.getenv("DB_PATH", "/app/data/whispr.db"))
+DATABASE_URL = f"sqlite:///{DB_PATH}"
+
+# No SQLAlchemy models to autogenerate from (yet)
+target_metadata = None
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    context.configure(
+        url=DATABASE_URL,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = create_engine(DATABASE_URL, poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/versions/0001_initial_schema.py
+++ b/backend/migrations/versions/0001_initial_schema.py
@@ -1,0 +1,56 @@
+"""initial schema
+
+Revision ID: 0001
+Revises: 
+Create Date: 2024-01-01 00:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        "events",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("ts", sa.Text, nullable=False),
+        sa.Column("event_type", sa.Text, nullable=False),
+        sa.Column("payload", sa.Text),
+    )
+
+    op.create_table(
+        "rules",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("name", sa.Text, nullable=False),
+        sa.Column("trigger_expr", sa.Text, nullable=False),
+        sa.Column("prompt_tpl", sa.Text, nullable=False),
+        sa.Column("is_active", sa.Integer, nullable=False, server_default="1"),
+    )
+
+    op.create_table(
+        "strategies",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("name", sa.Text, nullable=False),
+        sa.Column("description", sa.Text),
+        sa.Column("is_active", sa.Integer, nullable=False, server_default="1"),
+    )
+
+    op.create_table(
+        "indicator_data",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("ts", sa.Text, nullable=False),
+        sa.Column("indicator_name", sa.Text, nullable=False),
+        sa.Column("value", sa.Float, nullable=False),
+        sa.Column("metadata", sa.Text),
+    )
+
+def downgrade() -> None:
+    op.drop_table("indicator_data")
+    op.drop_table("strategies")
+    op.drop_table("rules")
+    op.drop_table("events")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,6 @@
 fastapi>=0.111
 uvicorn>=0.30
 aiosqlite>=0.19
-openai>=1.0.0 
+openai>=1.0.0
+alembic>=1.13
+SQLAlchemy>=2.0


### PR DESCRIPTION
## Summary
- integrate Alembic for database migrations
- define initial schema for events, rules, strategies and indicator data
- document migration workflow in backend README

## Testing
- `pip install -r backend/requirements.txt`
- `DB_PATH=test.db alembic upgrade head`
- `sqlite3 test.db '.tables'`
- `python -m py_compile database.py rules.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8da7b69fc8328a122076861865812