### PR TITLE
Add rule evaluation tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Backend tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: PYTHONPATH=backend pytest backend/tests

--- a/README.md
+++ b/README.md
@@ -223,3 +223,4 @@ The system comes with 3 test rules:
 3. **Check events**: `curl http://localhost:8000/last_events?limit=10`
 4. **View rules**: `curl http://localhost:8000/rules`
 5. **Monitor costs**: `curl http://localhost:8000/costs`
+6. **Run unit tests**: `pytest backend/tests` (also executed in CI)

--- a/backend/rules.py
+++ b/backend/rules.py
@@ -22,7 +22,15 @@ def _safe_eval(expr, context):
             right = _safe_eval(ast.unparse(tree.comparators[0]), context)
             op = SAFE_OPS[type(tree.ops[0])]
             return op(left, right)
-        return context.get(expr, expr)
+        if isinstance(tree, ast.Name):
+            return context.get(tree.id)
+        if isinstance(tree, ast.Constant):
+            return tree.value
+        if isinstance(tree, ast.BinOp) and isinstance(tree.op, ast.Mod):
+            left = _safe_eval(ast.unparse(tree.left), context)
+            right = _safe_eval(ast.unparse(tree.right), context)
+            return left % right
+        return False
     except Exception:
         return False
 

--- a/backend/tests/test_rules.py
+++ b/backend/tests/test_rules.py
@@ -1,0 +1,58 @@
+import pytest
+import sys
+import asyncio
+from pathlib import Path
+
+# Ensure backend modules are importable when tests are executed from repository root
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import rules
+from rules import _safe_eval, check_rules
+
+@pytest.mark.parametrize(
+    "expr, context, expected",
+    [
+        ("value >= 105", {"value": 105}, True),
+        ("value < 100", {"value": 105}, False),
+        ("value => 100", {"value": 101}, False),
+    ],
+)
+def test_safe_eval(expr, context, expected):
+    assert _safe_eval(expr, context) is expected
+
+def test_check_rules_triggers(monkeypatch):
+    sample_rules = [
+        {"id": 1, "name": "High", "expr": "value >= 105", "tpl": "High"},
+        {"id": 2, "name": "Low", "expr": "value <= 95", "tpl": "Low"},
+    ]
+
+    async def fake_load_rules():
+        return sample_rules
+
+    monkeypatch.setattr(rules, "load_rules", fake_load_rules)
+
+    tick_data = {"tick": 5, "value": 105}
+
+    async def collect():
+        return [r async for r in check_rules(tick_data)]
+
+    triggered = asyncio.run(collect())
+    assert [r["name"] for r in triggered] == ["High"]
+
+def test_check_rules_no_trigger(monkeypatch):
+    sample_rules = [
+        {"id": 1, "name": "High", "expr": "value >= 105", "tpl": "High"},
+    ]
+
+    async def fake_load_rules():
+        return sample_rules
+
+    monkeypatch.setattr(rules, "load_rules", fake_load_rules)
+
+    tick_data = {"tick": 1, "value": 100}
+
+    async def collect():
+        return [r async for r in check_rules(tick_data)]
+
+    triggered = asyncio.run(collect())
+    assert triggered == []


### PR DESCRIPTION
## Summary
- add `_safe_eval` support for literals and modulo
- test `_safe_eval` and `check_rules` with sample ticks
- run backend tests in GitHub Actions
- document how to run unit tests

## Testing
- `PYTHONPATH=backend pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8da83cb308328ad68c5602cab5968