### PR TITLE
Refactor rules and strategies with shared models

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,93 +1,110 @@
-from fastapi import FastAPI, WebSocket
+from __future__ import annotations
+
 import asyncio
 import json
-from database import log_event, get_db
-from llm import get_cost_comparison, call_llm
-from rules import check_rules, seed_test_rules
+
+from fastapi import FastAPI, WebSocket
+
+from database import get_db, log_event
+from llm import call_llm, get_cost_comparison
+from models import Rule, Strategy
+from rules import check_rules, load_rules, seed_test_rules
+from strategies import check_strategies, load_strategies
+
 
 app = FastAPI(title="Whispr-MVP")
 
+
 @app.on_event("startup")
-async def startup_event():
+async def startup_event() -> None:
     """Seed test rules on startup."""
     await seed_test_rules()
 
+
 @app.get("/")
-async def root():
+async def root() -> dict:
     return {"status": "OK", "message": "Whispr backend running"}
 
+
 @app.websocket("/ws/ticks")
-async def websocket_ticks(ws: WebSocket):
+async def websocket_ticks(ws: WebSocket) -> None:
     await ws.accept()
     tick = 0
     while True:
         tick_data = {"tick": tick, "value": 100 + tick}
-        await log_event("tick", tick_data)  # Log before broadcasting
+        await log_event("tick", tick_data)
         await ws.send_json(tick_data)
 
-        # NEW: evaluate rules
+        # Evaluate basic rules
         async for rule in check_rules(tick_data):
             try:
-                # Format prompt template with tick data
-                prompt = rule["tpl"].format(**tick_data)
-                
-                # Call LLM with the prompt
+                prompt = rule.prompt_tpl.format(**tick_data)
                 llm_response = await call_llm([
                     {"role": "user", "content": prompt}
                 ])
-                
-                # Create suggestion payload
+
                 suggestion_payload = {
                     "type": "suggestion",
-                    "rule_id": rule["id"],
-                    "rule_name": rule["name"],
+                    "rule_id": rule.id,
+                    "rule_name": rule.name,
                     "prompt": prompt,
                     "response": llm_response["content"],
                     "cost": llm_response["cost_estimate"],
                     "model": llm_response["model"],
-                    "tick_data": tick_data
+                    "tick_data": tick_data,
                 }
-                
-                # Log the prompt event
+
                 await log_event("prompt", {
-                    "rule_id": rule["id"],
+                    "rule_id": rule.id,
                     "prompt": prompt,
                     "response": llm_response["content"],
                     "cost": llm_response["cost_estimate"],
-                    "model": llm_response["model"]
+                    "model": llm_response["model"],
                 })
-                
-                # Send suggestion over WebSocket
+
                 await ws.send_json(suggestion_payload)
-                
-            except Exception as e:
-                # Log any errors
-                await log_event("rule_error", {
-                    "rule_id": rule["id"],
-                    "error": str(e)
-                })
-        
-        await asyncio.sleep(1)        # 1-Hz simulated stream
+
+            except Exception as e:  # pragma: no cover - logging only
+                await log_event("rule_error", {"rule_id": rule.id, "error": str(e)})
+
+        # Evaluate complex strategies (placeholder)
+        async for strat in check_strategies(tick_data):
+            await log_event(
+                "strategy_trigger",
+                {"strategy_id": strat.id, "name": strat.name},
+            )
+
+        await asyncio.sleep(1)
         tick += 1
 
+
 @app.get("/last_events")
-async def last_events(limit: int = 5):
+async def last_events(limit: int = 5) -> list:
     conn = await get_db()
     rows = await conn.execute_fetchall(
-        "SELECT ts, event_type, payload FROM events ORDER BY id DESC LIMIT ?", (limit,)
+        "SELECT ts, event_type, payload FROM events ORDER BY id DESC LIMIT ?",
+        (limit,),
     )
-    return [{"ts": r[0], "type": r[1], "payload": json.loads(r[2])} for r in rows]
+    return [
+        {"ts": r[0], "type": r[1], "payload": json.loads(r[2])}
+        for r in rows
+    ]
+
 
 @app.get("/costs")
-async def get_costs():
+async def get_costs() -> dict:
     """Get cost comparison for different LLM providers and models."""
     return get_cost_comparison()
 
-@app.get("/rules")
-async def get_rules():
+
+@app.get("/rules", response_model=list[Rule])
+async def get_rules() -> list[Rule]:
     """Get all active rules."""
-    conn = await get_db()
-    rows = await conn.execute_fetchall(
-        "SELECT id, name, trigger_expr, prompt_tpl, is_active FROM rules ORDER BY id"
-    )
-    return [{"id": r[0], "name": r[1], "trigger_expr": r[2], "prompt_tpl": r[3], "is_active": bool(r[4])} for r in rows] 
+    return await load_rules()
+
+
+@app.get("/strategies", response_model=list[Strategy])
+async def get_strategies() -> list[Strategy]:
+    """Get all active strategies."""
+    return await load_strategies()
+

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,28 @@
+"""Shared pydantic models used across backend modules."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class Rule(BaseModel):
+    """A simple rule with a boolean trigger expression."""
+
+    id: Optional[int] = None
+    name: str
+    trigger_expr: str
+    prompt_tpl: str
+    is_active: bool = True
+
+
+class Strategy(BaseModel):
+    """A complex strategy composed of multiple indicators or rules."""
+
+    id: Optional[int] = None
+    name: str
+    logic: str  # textual description or expression
+    rules: List[Rule] = []
+    is_active: bool = True
+

--- a/backend/rules.py
+++ b/backend/rules.py
@@ -1,7 +1,22 @@
-import json
+"""Rule evaluation module for simple expressions.
+
+This module deals with basic boolean expressions that can be evaluated
+directly against tick data. More complex multi-indicator logic lives in
+``strategies.py``.
+"""
+
+from __future__ import annotations
+
 import ast
 import operator
+from typing import AsyncIterator, Dict, List
+
 from database import get_db
+from models import Rule
+
+# ---------------------------------------------------------------------------
+# Safe expression evaluation
+# ---------------------------------------------------------------------------
 
 SAFE_OPS = {
     ast.Gt: operator.gt,
@@ -11,57 +26,89 @@ SAFE_OPS = {
     ast.Eq: operator.eq,
 }
 
-def _safe_eval(expr, context):
+
+def _safe_eval(expr: str, context: Dict[str, float | int]) -> bool:
+    """Safely evaluate a very small subset of Python expressions.
+
+    Only simple comparisons are supported, e.g. ``value > 105``. Any failure
+    during evaluation results in ``False`` to prevent unexpected behaviour.
     """
-    A very small and safe evaluator: supports comparisons like value > 105.
-    """
+
     try:
-        tree = ast.parse(expr, mode="eval").body  # type: ast.AST
+        tree = ast.parse(expr, mode="eval").body  # type: ignore[attr-defined]
         if isinstance(tree, ast.Compare):
             left = _safe_eval(ast.unparse(tree.left), context)
             right = _safe_eval(ast.unparse(tree.comparators[0]), context)
             op = SAFE_OPS[type(tree.ops[0])]
-            return op(left, right)
+            return op(left, right)  # type: ignore[arg-type]
         return context.get(expr, expr)
     except Exception:
         return False
 
-async def load_rules():
+
+# ---------------------------------------------------------------------------
+# CRUD helpers
+# ---------------------------------------------------------------------------
+
+async def load_rules() -> List[Rule]:
     """Load all active rules from the database."""
     conn = await get_db()
-    rows = await conn.execute_fetchall("SELECT id, name, trigger_expr, prompt_tpl FROM rules WHERE is_active=1")
-    return [dict(zip(("id", "name", "expr", "tpl"), r)) for r in rows]
+    rows = await conn.execute_fetchall(
+        "SELECT id, name, trigger_expr, prompt_tpl, is_active FROM rules WHERE is_active=1"
+    )
+    return [
+        Rule(
+            id=r[0],
+            name=r[1],
+            trigger_expr=r[2],
+            prompt_tpl=r[3],
+            is_active=bool(r[4]),
+        )
+        for r in rows
+    ]
 
-async def check_rules(tick):
-    """Check if any rules match the current tick data."""
+
+async def check_rules(tick: Dict[str, float | int]) -> AsyncIterator[Rule]:
+    """Yield rules that match the provided tick data."""
     for rule in await load_rules():
-        if _safe_eval(rule["expr"], tick):
+        if _safe_eval(rule.trigger_expr, tick):
             yield rule
 
-async def add_rule(name: str, trigger_expr: str, prompt_tpl: str):
-    """Add a new rule to the database."""
+
+async def add_rule(rule: Rule) -> None:
+    """Persist a new rule to the database."""
     conn = await get_db()
     await conn.execute(
-        "INSERT INTO rules (name, trigger_expr, prompt_tpl) VALUES (?, ?, ?)",
-        (name, trigger_expr, prompt_tpl)
+        "INSERT INTO rules (name, trigger_expr, prompt_tpl, is_active) VALUES (?, ?, ?, ?)",
+        (rule.name, rule.trigger_expr, rule.prompt_tpl, int(rule.is_active)),
     )
 
-async def seed_test_rules():
-    """Add some test rules to get started."""
+
+async def seed_test_rules() -> None:
+    """Add some sample rules to get started."""
     test_rules = [
-        ("High price ping", "value >= 105", "Price crossed {{value}}. Any risk-reducing actions?"),
-        ("Low price alert", "value <= 95", "Price dropped to {{value}}. Consider buying opportunity?"),
-        ("Tick milestone", "tick % 10 == 0", "Reached tick {{tick}} with value {{value}}. Market pattern analysis?")
+        Rule(
+            name="High price ping",
+            trigger_expr="value >= 105",
+            prompt_tpl="Price crossed {value}. Any risk-reducing actions?",
+        ),
+        Rule(
+            name="Low price alert",
+            trigger_expr="value <= 95",
+            prompt_tpl="Price dropped to {value}. Consider buying opportunity?",
+        ),
+        Rule(
+            name="Tick milestone",
+            trigger_expr="tick % 10 == 0",
+            prompt_tpl="Reached tick {tick} with value {value}. Market pattern analysis?",
+        ),
     ]
-    
+
     conn = await get_db()
-    for name, expr, tpl in test_rules:
-        # Check if rule already exists
+    for rule in test_rules:
         existing = await conn.execute_fetchall(
-            "SELECT id FROM rules WHERE name = ?", (name,)
+            "SELECT id FROM rules WHERE name = ?", (rule.name,)
         )
         if not existing:
-            await conn.execute(
-                "INSERT INTO rules (name, trigger_expr, prompt_tpl) VALUES (?, ?, ?)",
-                (name, expr, tpl)
-            ) 
+            await add_rule(rule)
+

--- a/backend/strategies.py
+++ b/backend/strategies.py
@@ -1,0 +1,27 @@
+"""Strategy evaluation module for complex multi-indicator logic."""
+
+from __future__ import annotations
+
+from typing import AsyncIterator, Dict, List
+
+from models import Strategy
+from rules import _safe_eval
+
+
+async def load_strategies() -> List[Strategy]:
+    """Load active strategies.
+
+    For now this function returns an empty list, but it can be extended to
+    pull strategies from a database or configuration file.
+    """
+
+    return []
+
+
+async def check_strategies(tick: Dict[str, float | int]) -> AsyncIterator[Strategy]:
+    """Yield strategies whose logic evaluates to True for the given tick."""
+
+    for strat in await load_strategies():
+        if _safe_eval(strat.logic, tick):
+            yield strat
+


### PR DESCRIPTION
## Summary
- add shared `Rule` and `Strategy` pydantic models
- split simple rule checks and complex strategy logic into separate modules
- expose `/strategies` endpoint and use models across API

## Testing
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_68a8da7ef9f08328b2749fa06923e2cd